### PR TITLE
Simplify Plot.jsx

### DIFF
--- a/exoplanet-transit-simulator/package.json
+++ b/exoplanet-transit-simulator/package.json
@@ -9,7 +9,7 @@
     "serve": "webpack-dev-server",
     "dev": "webpack --mode development --watch",
     "build": "webpack --mode production",
-    "eslint": "eslint src/*.jsx"
+    "eslint": "eslint src/*.jsx src/**/*.jsx"
   },
   "repository": {
     "type": "git",

--- a/exoplanet-transit-simulator/src/Lightcurve.js
+++ b/exoplanet-transit-simulator/src/Lightcurve.js
@@ -9,8 +9,8 @@ export default class Lightcurve {
         if (typeof this.width === 'undefined' ||
             typeof this.height === 'undefined'
            ) {
-            this.width = 480;
-            this.height = 280;
+            this.width = 400;
+            this.height = 240;
         }
 
         this._xscale = 100;

--- a/exoplanet-transit-simulator/src/LightcurveView.jsx
+++ b/exoplanet-transit-simulator/src/LightcurveView.jsx
@@ -66,7 +66,8 @@ export default class LightcurveView extends React.Component {
                 showTheoreticalCurve={this.props.showTheoreticalCurve}
                 showSimulatedMeasurements={this.props.showSimulatedMeasurements}
                 planetRadius={this.props.planetRadius}
-                width={460} height={280}
+                width={460}
+                height={280}
                 paddingLeft={60}
                 padding={20} />
         );
@@ -74,13 +75,6 @@ export default class LightcurveView extends React.Component {
     }
     componentDidUpdate(prevProps) {
         if (this.props.showSimulatedMeasurements) {
-            if (
-                prevProps.planetRadius !== this.props.planetRadius
-            ) {
-                this.setState({
-                    noiseData: this.getNoiseData(this.props.curveCoords)
-                });
-            }
             if (
                 prevProps.simMeasurementNumber !== this.props.simMeasurementNumber ||
                 prevProps.noise !== this.props.noise

--- a/exoplanet-transit-simulator/src/d3/Axis.jsx
+++ b/exoplanet-transit-simulator/src/d3/Axis.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 
 export default class Axis extends Component {
@@ -37,3 +38,8 @@ export default class Axis extends Component {
         </React.Fragment>;
     }
 }
+
+Axis.propTypes = {
+    yScale: PropTypes.func.isRequired,
+    paddingLeft: PropTypes.number.isRequired
+};

--- a/exoplanet-transit-simulator/src/d3/DataCircles.jsx
+++ b/exoplanet-transit-simulator/src/d3/DataCircles.jsx
@@ -1,30 +1,38 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 
-const renderCircles = props => {
-    return (coords, index) => {
+
+class DataCircles extends Component {
+    renderCircles(coords, index) {
         const circleProps = {
-            cx: props.xScale(coords[0]),
-            cy: props.yScale(coords[1]),
+            cx: this.props.xScale(coords[0]),
+            cy: this.props.yScale(coords[1]),
             r: 2,
             fill: '#909090',
             key: index
         };
         return <circle {...circleProps} />;
-    };
-};
+    }
+    render() {
+        const data = this.props.data;
+        const y = this.props.yScale;
 
-const DataCircles = props => {
-    const data = props.data;
-    const y = props.yScale;
+        // Scale the data points like in Line.render().
+        // Only the y axis needs to be scaled.
+        data.forEach(function() {
+            y.domain(d3.extent(data, function(dd) { return dd[1]; }));
+        });
 
-    // Scale the data points like in Line.render().
-    // Only the y axis needs to be scaled.
-    data.forEach(function(d) {
-        y.domain(d3.extent(data, function(d) { return d[1]; }));
-    });
+        return <g>{this.props.data.map(
+                this.renderCircles.bind(this))}</g>;
+    }
+}
 
-    return <g>{props.data.map(renderCircles(props))}</g>;
+DataCircles.propTypes = {
+    data: PropTypes.array.isRequired,
+    xScale: PropTypes.func.isRequired,
+    yScale: PropTypes.func.isRequired
 };
 
 export default DataCircles;

--- a/exoplanet-transit-simulator/src/d3/PhaseControl.jsx
+++ b/exoplanet-transit-simulator/src/d3/PhaseControl.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const PhaseControl = props => {
     const xPos = props.phase * (
@@ -8,6 +9,14 @@ const PhaseControl = props => {
                  x2={xPos} y2={props.height - props.padding}
                  cursor="pointer"
                  stroke="#ff7070" strokeWidth={3} />;
+};
+
+PhaseControl.propTypes = {
+    phase: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+    padding: PropTypes.number.isRequired,
+    paddingLeft: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired
 };
 
 export default PhaseControl;


### PR DESCRIPTION
Getting the original lightcurve code to display correctly in d3 has been
more difficult that I expected. I can't get the data to look correct.

So far, I've at least simplified a few things in Plot.jsx so there's
less going on, making it easier to deal with.

Also, I realized eslint wasn't checking the `d3` sub-directory, so I've
fixed that.
