### PR TITLE
Lunar sim: Fix moon phase bug - closes HEL-62

### DIFF
--- a/lunar-phase-simulator/src/MoonPhaseView.jsx
+++ b/lunar-phase-simulator/src/MoonPhaseView.jsx
@@ -135,7 +135,7 @@ export default class MoonPhaseView extends React.Component {
             rightShade.scale.x = scale;
             rightShade.position.x = this.center.x - (scale * this.center.x);
 
-            if (phase >= 0.25) {
+            if (phase > 0.25) {
                 this.hiddenMoon.mask = this.rightShade;
                 this.hiddenMoon.visible = true;
             } else {
@@ -148,7 +148,7 @@ export default class MoonPhaseView extends React.Component {
             rightShade.scale.x = 1;
             rightShade.position.x = 0;
 
-            if (phase <= 0.75) {
+            if (phase < 0.75) {
                 this.hiddenMoon.mask = this.leftShade;
                 this.hiddenMoon.visible = true;
                 leftShade.scale.x = -scale;


### PR DESCRIPTION
This fixes a bug where the moon displayed as full when First or Third
quarter was selected from the dropdown in Chrome.