### PR TITLE
Lunar sim: update to Pixi 5.0.0-rc.

### DIFF
--- a/lunar-phase-simulator/package-lock.json
+++ b/lunar-phase-simulator/package-lock.json
@@ -847,6 +847,463 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@pixi/accessibility": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.0.0-rc.tgz",
+      "integrity": "sha512-PbP8p5hxFkil0mXQfKqZSxaKt1FfKQxEAoRRPtc2ekx+PY64CG2OtDDKM0fQyMUhwMd/bD7y7TRbH/pYUiilaA==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc",
+        "ismobilejs": "^0.5.1"
+      }
+    },
+    "@pixi/app": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.0.0-rc.tgz",
+      "integrity": "sha512-MDbxyxNB1/+dQBZnboXFW4ZfaSaOXhKyaspD9Tqx9yvxnS0yzHmX3bKYvoBCpwbbgOSoBI3yW59U4FPHCcNtaQ==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-display": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-display/-/canvas-display-5.0.0-rc.tgz",
+      "integrity": "sha512-ULGAs7EshIKzOCIjRrMyJY3mIYk9SRZR5VP8xxpqOb98Mdi/9jjZwvOnx6wVKdlEsvzOTsbjYXVdjTbHdUQFzQ==",
+      "requires": {
+        "@pixi/display": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-extract": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-extract/-/canvas-extract-5.0.0-rc.tgz",
+      "integrity": "sha512-fLvyRBz7IJCvGO5NYyLyciLAp2nfwqTj5QctJ/XCL+9Eypbys4CK4sE0RY27eDqIaqWCT951hHnsvE0u81z6qg==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-graphics": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-graphics/-/canvas-graphics-5.0.0-rc.tgz",
+      "integrity": "sha512-8WOfSlB0ai5xcwW08ojR+ux3qRtdeCpYTQsil+GnTpayAli+gikmREv4qOzsDxrgBT3JhiZPq52ikYWzJcUWBw==",
+      "requires": {
+        "@pixi/canvas-renderer": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/graphics": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-mesh": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-mesh/-/canvas-mesh-5.0.0-rc.tgz",
+      "integrity": "sha512-RgjVUwkWsRvn+PbJCeDh3LFTX2hdlFBO6qxHihvWMkccw//1L6ShTmW8Bi6tuooPfQ2+80EhE18Dv5SuaR3R0Q==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/mesh": "^5.0.0-rc",
+        "@pixi/mesh-extras": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-particles": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-particles/-/canvas-particles-5.0.0-rc.tgz",
+      "integrity": "sha512-HhXM+d/AvbEPxAXDfu9pYucSJifq2btuEk52hjoqIRy7CCY6s7w/x0Piinnq4Jwu5wA4kTkZV0z/FgBfKQp+zg==",
+      "requires": {
+        "@pixi/particles": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-prepare": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-prepare/-/canvas-prepare-5.0.0-rc.tgz",
+      "integrity": "sha512-YeiGVkKcloYZLpKdTuEx/mm1SD8wDKWyKQwBSdq13ldbJYHo+yTv+K2ZWNHZ2IuU0Alyj5Bcqwhgj/1qvoQ8Kg==",
+      "requires": {
+        "@pixi/canvas-renderer": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/prepare": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-renderer": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-5.0.0-rc.tgz",
+      "integrity": "sha512-bwHE3P0+A8Roz9nvtIPHbN+CB/iD2c/mKn3UBU0E7IU612UuYWx9HudRhAxsk1S5rVsd0zH8C1z5Gp/dlV8bsQ==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-sprite": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-sprite/-/canvas-sprite-5.0.0-rc.tgz",
+      "integrity": "sha512-xu5HM27vC7gv7I0wJZFdzKSvbyuzmLFpQ2kvm5hZtxcWzgEISIhr490RePrhtOGBXgdC2W7ucciqYAlnMJW45g==",
+      "requires": {
+        "@pixi/canvas-renderer": "^5.0.0-rc",
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/sprite": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/canvas-sprite-tiling": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-sprite-tiling/-/canvas-sprite-tiling-5.0.0-rc.tgz",
+      "integrity": "sha512-kZM7xrhP0C6t0N0os4Z0dXkK9zseVvHf0KgV0k6YBu+wETyTbW3wn1ucTPUPQi9yqZa33jpaoaJETBMEspLUmA==",
+      "requires": {
+        "@pixi/canvas-sprite": "^5.0.0-rc",
+        "@pixi/sprite-tiling": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/constants": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.0.0-rc.tgz",
+      "integrity": "sha512-3IE74dkIIvdOavEZy7gOJHPRBT0nLP6g5wmHEad9VF81bUzcqR5HebcpntN0TBdELglupPYR4QkrjuyPPAUELw==",
+      "requires": {
+        "ismobilejs": "^0.5.1"
+      }
+    },
+    "@pixi/core": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.0.0-rc.tgz",
+      "integrity": "sha512-n08Tdz35l2RneM7PnSSAmNxuyn7W1SDl8Nsk206UG056sxp+Pbf6TZ5HfJeUOsTXdJ6Mu5Pcp9gkrsRY7UBJEQ==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/ticker": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc",
+        "eventemitter3": "^2.0.0",
+        "ismobilejs": "^0.5.1",
+        "mini-runner": "^1.0.1"
+      }
+    },
+    "@pixi/display": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.0.0-rc.tgz",
+      "integrity": "sha512-3Y6PfIQZkxpLJMthPo++JcEt82w0yBDUoIVbHO2lxRkfMsFsBbjqKRoU4e8ebYYIEjtYZkr7/ldYKNFVV++V2Q==",
+      "requires": {
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc",
+        "eventemitter3": "^2.0.0",
+        "remove-array-items": "^1.0.0"
+      }
+    },
+    "@pixi/extract": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.0.0-rc.tgz",
+      "integrity": "sha512-wyUcpvvRSPEWMAkgu74q/kE/1vSrFUvz0X6Ulc1s+Rgf+zoGa2jTkngpevOWrHCh1Wt+6XG7g3kJ7widjvh21A==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/filter-alpha": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.0.0-rc.tgz",
+      "integrity": "sha512-kobhWlm6YC/9g22A2twt4B9qlVjwaGw4Qc48Xwl3wcVjFtXv2f9t6ha7hP276jrsg3EK+QJxQgcY+VA66QVFaw==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/fragments": "^5.0.0-rc"
+      }
+    },
+    "@pixi/filter-blur": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.0.0-rc.tgz",
+      "integrity": "sha512-QyErPMsiBVuQBY1+Ym2Jh/hduk3lf5yhLyuXd29g1o63elubMwoHovnG8J/J2tF0FA+sOYkLeRUv/9CTcjxYow==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc"
+      }
+    },
+    "@pixi/filter-color-matrix": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.0.0-rc.tgz",
+      "integrity": "sha512-BNxcUvmhfTJ6eiMa0DMVSetXhpi+57Yo9+nsMJTm56m2viwkL47pdCn8INC2lVhCblj/u0dNcbyRgd06dodhRg==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/fragments": "^5.0.0-rc"
+      }
+    },
+    "@pixi/filter-displacement": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.0.0-rc.tgz",
+      "integrity": "sha512-0t5j6meS7p8N7TW02+3/MnzdeKsHt6FPttdnhRB8wtY7t9BkAnGvdzrFhrq9jML/ZLBYZKT6jUV5mWkWswZ0mg==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc"
+      }
+    },
+    "@pixi/filter-fxaa": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.0.0-rc.tgz",
+      "integrity": "sha512-BjTnLivSqN0O2L5nlmZgcYQQVBh3SofaG+XZOA7gVrfCHvl71U9Rg0TsaQopbOq6yzN+j26g/I3DVSvotNLe1w==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc"
+      }
+    },
+    "@pixi/filter-noise": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.0.0-rc.tgz",
+      "integrity": "sha512-OBXUvnoImj2GJemGurSN9Rn67n+HgaINfE6faf7A6qmKbIlAv1aKQOoXgnFzozsivcxlq/+xrHMdIUoaPqowXg==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/fragments": "^5.0.0-rc"
+      }
+    },
+    "@pixi/fragments": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/fragments/-/fragments-5.0.0-rc.tgz",
+      "integrity": "sha512-70gHrmovMULM26szIvyaPD4HA6Dnlkbs7F0jlF2hp2InD8UAcJmVmTjPHYgOVMLyVPYaIktnULJM6BsZ67raeg==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc"
+      }
+    },
+    "@pixi/graphics": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.0.0-rc.tgz",
+      "integrity": "sha512-kQ2GznQ8ZNLMUw/C3kk4Jvc17uUh7KQg8rCTF1zVLZSiKf5Q1EnT5k93gY9HFTgRTF0tY51LWWRCd2y7cqe/Mw==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/sprite": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/interaction": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.0.0-rc.tgz",
+      "integrity": "sha512-5fMc9CQrXMv9fMdgxO64ozRwwCmWgWFzIVio6mSK4Ex/8VY0ooQAOx07y/XrT4TsKl87dJanhmd/uwBOaWmwVA==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/ticker": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc",
+        "eventemitter3": "^2.0.0"
+      }
+    },
+    "@pixi/loaders": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.0.0-rc.tgz",
+      "integrity": "sha512-tvVNlGiAgSNXRDK3tbh/JG9686yJm7T8eTIbucf3A8EvHPU+SgKE5pw6DoGX6GcUieYgoN+eB8d8CBooZSXPWg==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc",
+        "eventemitter3": "^2.0.0",
+        "resource-loader": "^2.2.3"
+      }
+    },
+    "@pixi/math": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.0.0-rc.tgz",
+      "integrity": "sha512-+142rN0Sc0YgTJ42KQ8Bc+RhyWcIG+gOWv4tVwrWWhiBZafPHGw0yT36lhJNidcKgdEhBX+PcFaaJkz8SN4reg=="
+    },
+    "@pixi/mesh": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.0.0-rc.tgz",
+      "integrity": "sha512-JdzFfZxfHuzgRYbz9zzpl4VYD4MAmGhB/x5OVKMVmS6XtCeNCZofOAdosFpXuIvLQK4sY1xfFPJnBBI26ndrDA==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/mesh-extras": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.0.0-rc.tgz",
+      "integrity": "sha512-EWDViOoHqtRoALih6YgLQBivNoVDf04gxKye9vamSxQAJMDL5pK+DqIxTMvXHP9aA2icXWIugJWhtwE51fRqTA==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/mesh": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/mixin-cache-as-bitmap": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.0.0-rc.tgz",
+      "integrity": "sha512-lwmGeTUiCDOLnVEnRfiipwEXKF5kNaXUu4ra0NxKNfm0BUPuQuMcT1Lo1RT5PNh831jkQSdBoP14nENOqacSZw==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/sprite": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/mixin-get-child-by-name": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.0.0-rc.tgz",
+      "integrity": "sha512-kSiKVTXFj4zdH+EsKXhXZDim4qKVGFjBNSNXvyc28/rrzxDBp3CdT3BSM4MJ9e/xI1PfZ7B7P5BOCnraWLFDjQ==",
+      "requires": {
+        "@pixi/display": "^5.0.0-rc"
+      }
+    },
+    "@pixi/mixin-get-global-position": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.0.0-rc.tgz",
+      "integrity": "sha512-qq89GjrEZtj0bXpG6E4niJKvYxxOtjGAxk4smPL56zL/TF5zHWY4L4c610U/DHpSXAjnr4qqRv7HDpiugmS46A==",
+      "requires": {
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc"
+      }
+    },
+    "@pixi/particles": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.0.0-rc.tgz",
+      "integrity": "sha512-L86VUXTVRF4p9x9xMG7Ga8xjhojzGeSxRNQZ2spxZWh75OMadEOyeFwSOeVi/BM1RD/Bz032w3fhegWgWvQsrA==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/polyfill": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.0.0-rc.tgz",
+      "integrity": "sha512-eP00LrFRlBwZ3rlkJ1+26h2fZlBXhyBNrnu8u2ptzWxEfMi4AMsF/rSmN24GQ7VSxdk5U197ham3RtOwDBcskw==",
+      "requires": {
+        "es6-promise-polyfill": "^1.2.0",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "@pixi/prepare": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.0.0-rc.tgz",
+      "integrity": "sha512-J8w/X9sOTIvq0nNdp48xBfdKTkqTnfV4hqq+osEyQsBrRAfeXpYbUPZnjd+KzaHxbiJQamoS1nefwebo4TgPhg==",
+      "requires": {
+        "@pixi/canvas-renderer": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/graphics": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/text": "^5.0.0-rc",
+        "@pixi/ticker": "^5.0.0-rc"
+      }
+    },
+    "@pixi/settings": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.0.0-rc.tgz",
+      "integrity": "sha512-bkPgUV9ty5fQQ+204zTI4hiu5eXLY5jSjiDqhU7okeNQ7/k51JO0bBNbVa2VnQyk/fkfqGKWDoj+wnjWw4Aceg==",
+      "requires": {
+        "ismobilejs": "^0.5.1"
+      }
+    },
+    "@pixi/sprite": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.0.0-rc.tgz",
+      "integrity": "sha512-wqy81pfBQqrT//spCVn/AN4t469Ucim/3xYmPoxprIXcO8nzMR01LYBLjXn1Ls9cJETpc/G9oDjD2PCcgXMeGg==",
+      "requires": {
+        "@pixi/canvas-renderer": "^5.0.0-rc",
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/sprite-animated": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.0.0-rc.tgz",
+      "integrity": "sha512-4sRRkqJZheAcxSZWPMs7YtsvLdtJNf5w2Nwdbkf3x/bHW5NSYFnvdI4F+GwzEwI6DqVqQw/byjDr+lC5cQxykg==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/sprite": "^5.0.0-rc",
+        "@pixi/ticker": "^5.0.0-rc"
+      }
+    },
+    "@pixi/sprite-tiling": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.0.0-rc.tgz",
+      "integrity": "sha512-9XDDAtkKLO4aEcR8+SonGP46FHXmsy3WhiapovEtyIuwIilkOpOzCh2TvVnkVQUxff+vZ/F+JFMpXMDmjtlxLQ==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/sprite": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/spritesheet": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.0.0-rc.tgz",
+      "integrity": "sha512-ORaFU7CmrT65nv8QAHMbVA9Npos7Xia77YnCHvMh5ztMPCEy4lof78C0pOzPyXTI4UMOAEhorQpNvjWZCrKt1w==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/loaders": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc",
+        "url": "^0.11.0"
+      }
+    },
+    "@pixi/text": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.0.0-rc.tgz",
+      "integrity": "sha512-nNj/X2evBxYpVowaJpUJOeVakdKiU7Wi18eAoY1DPqcWz9bIuVFwgO8jcbxSdi0iWN9mHFxLd5yZ/eLCHtVkmg==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/sprite": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/text-bitmap": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.0.0-rc.tgz",
+      "integrity": "sha512-d5XMx6CDx9zDP6/R9ZAo/kMMVJjxEs5xChk2EiUlsCHBCfNR0aqFgcJR5sWjU5o8ZW8s6/SDOFypfT4bNV3j2g==",
+      "requires": {
+        "@pixi/core": "^5.0.0-rc",
+        "@pixi/display": "^5.0.0-rc",
+        "@pixi/loaders": "^5.0.0-rc",
+        "@pixi/math": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "@pixi/sprite": "^5.0.0-rc",
+        "@pixi/utils": "^5.0.0-rc"
+      }
+    },
+    "@pixi/ticker": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.0.0-rc.tgz",
+      "integrity": "sha512-4I3RfIW3gXRxzShW2ebxuFcvC8MWEFoGZbqpASMetG0gey5LuvRC5ChemEyuqhn6f6Gf4B24OcMnhPUD6pHB1Q==",
+      "requires": {
+        "@pixi/settings": "^5.0.0-rc"
+      }
+    },
+    "@pixi/utils": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.0.0-rc.tgz",
+      "integrity": "sha512-gqD3nEaR4X8rHe881KFYE9WDy0v2Ve+2phsKtC36cZIRDpQp/1YOmJa4Rpb25vp3cH87gB/UgYXqwm7dbf+RZg==",
+      "requires": {
+        "@pixi/constants": "^5.0.0-rc",
+        "@pixi/settings": "^5.0.0-rc",
+        "earcut": "^2.1.3",
+        "eventemitter3": "^2.0.0",
+        "ismobilejs": "^0.5.1",
+        "remove-array-items": "^1.0.0",
+        "url": "^0.11.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -1789,11 +2246,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
       "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw=="
-    },
-    "bit-twiddle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
     },
     "bluebird": {
       "version": "3.5.3",
@@ -2976,6 +3428,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
+      "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -7092,6 +7549,11 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mini-runner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mini-runner/-/mini-runner-1.0.1.tgz",
+      "integrity": "sha1-ScThq5i3BZP6A5iFCLqeKaYXZEQ="
+    },
     "mini-signals": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
@@ -7838,24 +8300,63 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pixi-gl-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pixi-gl-core/-/pixi-gl-core-1.1.4.tgz",
-      "integrity": "sha1-i0tcQzsx5Bm8N53FZc4bg1qRs3I="
-    },
-    "pixi.js": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-4.8.5.tgz",
-      "integrity": "sha512-eYGvuzIOAOepoFDHu3GmvRqM2tJ/IBwHnfxB6BxGxDOQOaNfWMT9LA5IlUY9K3YEnEd3YtD0Nsx5aRxCyzYQeQ==",
+    "pixi.js-legacy": {
+      "version": "5.0.0-rc",
+      "resolved": "https://registry.npmjs.org/pixi.js-legacy/-/pixi.js-legacy-5.0.0-rc.tgz",
+      "integrity": "sha512-KKmQXi5KGHVmQ8XpDv6GmgMweoMpqu6X8JIKnK566oLr6rvsJxTK8l+BwRInJ67zcF0VU6IxgGQ8J1X/Khcldw==",
       "requires": {
-        "bit-twiddle": "^1.0.2",
-        "earcut": "^2.1.4",
-        "eventemitter3": "^2.0.0",
-        "ismobilejs": "^0.5.1",
-        "object-assign": "^4.0.1",
-        "pixi-gl-core": "^1.1.4",
-        "remove-array-items": "^1.0.0",
-        "resource-loader": "^2.2.3"
+        "@pixi/canvas-display": "^5.0.0-rc",
+        "@pixi/canvas-extract": "^5.0.0-rc",
+        "@pixi/canvas-graphics": "^5.0.0-rc",
+        "@pixi/canvas-mesh": "^5.0.0-rc",
+        "@pixi/canvas-particles": "^5.0.0-rc",
+        "@pixi/canvas-prepare": "^5.0.0-rc",
+        "@pixi/canvas-renderer": "^5.0.0-rc",
+        "@pixi/canvas-sprite": "^5.0.0-rc",
+        "@pixi/canvas-sprite-tiling": "^5.0.0-rc",
+        "@pixi/polyfill": "^5.0.0-rc",
+        "pixi.js": "^5.0.0-rc"
+      },
+      "dependencies": {
+        "pixi.js": {
+          "version": "5.0.0-rc",
+          "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.0.0-rc.tgz",
+          "integrity": "sha512-C6Gc09RPKEoejeklaPnPJxY3jPXcPBXjri5tsEYQCEh5unVA+BBPzrPcofJyvvTolNgdONTZ76yk5QQ+qi0bqg==",
+          "requires": {
+            "@pixi/accessibility": "^5.0.0-rc",
+            "@pixi/app": "^5.0.0-rc",
+            "@pixi/constants": "^5.0.0-rc",
+            "@pixi/core": "^5.0.0-rc",
+            "@pixi/display": "^5.0.0-rc",
+            "@pixi/extract": "^5.0.0-rc",
+            "@pixi/filter-alpha": "^5.0.0-rc",
+            "@pixi/filter-blur": "^5.0.0-rc",
+            "@pixi/filter-color-matrix": "^5.0.0-rc",
+            "@pixi/filter-displacement": "^5.0.0-rc",
+            "@pixi/filter-fxaa": "^5.0.0-rc",
+            "@pixi/filter-noise": "^5.0.0-rc",
+            "@pixi/graphics": "^5.0.0-rc",
+            "@pixi/interaction": "^5.0.0-rc",
+            "@pixi/loaders": "^5.0.0-rc",
+            "@pixi/math": "^5.0.0-rc",
+            "@pixi/mesh": "^5.0.0-rc",
+            "@pixi/mesh-extras": "^5.0.0-rc",
+            "@pixi/mixin-cache-as-bitmap": "^5.0.0-rc",
+            "@pixi/mixin-get-child-by-name": "^5.0.0-rc",
+            "@pixi/mixin-get-global-position": "^5.0.0-rc",
+            "@pixi/particles": "^5.0.0-rc",
+            "@pixi/prepare": "^5.0.0-rc",
+            "@pixi/settings": "^5.0.0-rc",
+            "@pixi/sprite": "^5.0.0-rc",
+            "@pixi/sprite-animated": "^5.0.0-rc",
+            "@pixi/sprite-tiling": "^5.0.0-rc",
+            "@pixi/spritesheet": "^5.0.0-rc",
+            "@pixi/text": "^5.0.0-rc",
+            "@pixi/text-bitmap": "^5.0.0-rc",
+            "@pixi/ticker": "^5.0.0-rc",
+            "@pixi/utils": "^5.0.0-rc"
+          }
+        }
       }
     },
     "pkg-dir": {
@@ -8057,8 +8558,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -9849,7 +10349,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -9858,8 +10357,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },

--- a/lunar-phase-simulator/package.json
+++ b/lunar-phase-simulator/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/ccnmtl/astro-simulations#readme",
   "dependencies": {
     "@babel/cli": "^7.0.0",
-    "pixi.js": "~4.8.5",
+    "pixi.js-legacy": "~5.0.0-rc",
     "react": "~16.8.0",
     "react-dom": "~16.8.0",
     "react-range-step-input": "^1.2.1",

--- a/lunar-phase-simulator/src/MainView.jsx
+++ b/lunar-phase-simulator/src/MainView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as PIXI from 'pixi.js';
+import * as PIXI from 'pixi.js-legacy';
 import {degToRad, radToDeg, roundToOnePlace} from './utils';
 
 /**
@@ -55,6 +55,7 @@ export default class MainView extends React.Component {
             // guessing there's just some filters or settings I can add
             // to make it look good in webgl.
             forceCanvas: true,
+            antialias: true,
 
             // as far as I know the ticker isn't necessary at the
             // moment.
@@ -186,8 +187,7 @@ export default class MainView extends React.Component {
     }
     drawOrbit() {
         const graphics = new PIXI.Graphics();
-        graphics.lineColor = 0xffffff;
-        graphics.lineWidth = 1;
+        graphics.lineStyle(1, 0xffffff);
         graphics.drawCircle(this.orbitCenter.x, this.orbitCenter.y, 200);
         this.app.stage.addChild(graphics);
     }
@@ -274,8 +274,7 @@ export default class MainView extends React.Component {
         const landmark = new PIXI.Graphics();
         landmark.name = 'landmark';
         landmark.visible = false;
-        landmark.lineColor = 0xff95ff;
-        landmark.lineWidth = 4;
+        landmark.lineStyle(4, 0xff95ff);
         landmark.moveTo(-10, 0);
         landmark.lineTo(-20, 0);
         this.landmark = landmark;
@@ -365,8 +364,7 @@ export default class MainView extends React.Component {
     drawArrows() {
         for (let i = 1; i < 8; i++) {
             let line = new PIXI.Graphics();
-            line.lineColor = 0xffff80;
-            line.lineWidth = 2;
+            line.lineStyle(2, 0xffff80);
 
             line.moveTo(60, i * 50 + 30);
             line.lineTo(120, i * 50 + 30);

--- a/lunar-phase-simulator/src/MoonPhaseView.jsx
+++ b/lunar-phase-simulator/src/MoonPhaseView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as PIXI from 'pixi.js';
+import * as PIXI from 'pixi.js-legacy';
 import {
     forceNumber, degToRad, getPercentIlluminated,
     roundToOnePlace, getPhaseSlot, getTimeSinceNewMoon, formatInterval


### PR DESCRIPTION
The separate "legacy" package needs to be used in order to use the
canvas rendering. I don't fully understand why yet - see:
  https://github.com/pixijs/pixi.js/issues/5417

Anyways, it would be good to get these 2d scenes displaying correctly with
WebGL, as that's really the direction pixi seems to be going in.