### PR TITLE
Transit sim: Use original code for star functions

### DIFF
--- a/exoplanet-transit-simulator/src/main.jsx
+++ b/exoplanet-transit-simulator/src/main.jsx
@@ -6,13 +6,14 @@ import TransitView from './TransitView';
 import {RangeStepInput} from 'react-range-step-input';
 
 import {
-    forceNumber, getStarRadius, getStarTemp, getSpectralType,
+    forceNumber, getStarRadius,
     formatNumber, getTimeString
 } from './utils';
 
 import {
     getLuminosityFromMass, getTempFromLuminosity,
-    getRadiusFromTempAndLuminosity
+    getRadiusFromTempAndLuminosity,
+    getSpectralTypeFromTemp
 } from './star-utils';
 
 import {systemPresets} from './presets';
@@ -151,8 +152,13 @@ class ExoplanetTransitSimulator extends React.Component {
         }
     }
     render() {
-        const starType = getSpectralType(this.state.starMass);
-        const starTemp = getStarTemp(this.state.starMass);
+
+        const lum = getLuminosityFromMass(this.state.starMass);
+        const starTemp = getTempFromLuminosity(lum);
+
+        const st = getSpectralTypeFromTemp(starTemp);
+        const starType = st.type + Math.round(st.number) + st.starClass;
+
         const starRadius = getStarRadius(this.state.starMass);
         return <React.Fragment>
             <nav className="navbar navbar-expand-md navbar-light bg-light d-flex justify-content-between">
@@ -453,7 +459,7 @@ class ExoplanetTransitSimulator extends React.Component {
                     </div>
                     <p>
                         A main sequence star of this mass would have
-                        spectral type {starType}, temperature {starTemp} K, and
+                        spectral type {starType}, temperature {Math.round(starTemp)} K, and
                         radius {starRadius} R<sub>sun</sub>
                     </p>
                 </div>

--- a/exoplanet-transit-simulator/src/utils.js
+++ b/exoplanet-transit-simulator/src/utils.js
@@ -24,48 +24,6 @@ const getStarRadius = function(starMass) {
     return roundToOnePlace(starMass * 0.8);
 };
 
-/*
- * TODO:
- * port getTempFromLuminosity() from original code.
- */
-const getStarTemp = function(starMass) {
-    return Math.round(starMass * 3226.6666667 + 2583);
-};
-
-/**
- * Given a star's mass, return the spectral type it would have.
- *
- * The range of star mass that's used (0.5 to 2) ranges from types K7V
- * to A2V.
- */
-const getSpectralType = function(starMass) {
-    const types = [
-        'K7V', 'K6V', 'K5V', 'K4V',
-        'K3V', 'K2V', 'K1V', 'K0V',
-
-        'G9V', 'G8V', 'G7V', 'G6V',
-        'G5V', 'G4V', 'G3V', 'G2V',
-        'G1V', 'G0V',
-
-        'F9V', 'F8V', 'F7V', 'F6V',
-        'F5V', 'F4V', 'F3V', 'F2V',
-        'F1V', 'F0V',
-
-        'A9V', 'A8V', 'A7V', 'A6V',
-        'A5V', 'A4V', 'A3V', 'A2V'
-    ];
-
-    // Convert starMass to a number between 0 and 1.
-    const s = (starMass - 0.5) / 1.5;
-
-    // Convert s to an index between 0 and types.length - 1.
-    // TODO: it looks like the relationship isn't actually linear, so
-    // I'll have to fix that.
-    const i = Math.round(s * (types.length - 1));
-
-    return types[i];
-};
-
 /**
  * Convert unit from rJupiter to kilometers.
  *
@@ -206,8 +164,6 @@ export {
     forceNumber,
     roundToOnePlace,
     getStarRadius,
-    getStarTemp,
-    getSpectralType,
     rJupToKm, rSunToKm,
     kmToPx,
     getDist,


### PR DESCRIPTION
This removes a few functions I made myself that were approximately
correct, but not completely.