### PR TITLE
Add version and build info to About modal windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ test-all:
 
 all:
 	@$(foreach dir, $(sims), cd $(dir) && npm i && npm run build && cd ..;)
+	@$(foreach dir, $(sims), ./scripts/update-build-info.py $(dir))
+
+update-build-info:
+	@$(foreach dir, $(sims), ./scripts/update-build-info.py $(dir);)
 
 clean:
 	@$(foreach dir, $(sims), cd $(dir) && rm -rf node_modules package-lock.json && cd ..;)

--- a/eclipsing-binary-simulator/index.html
+++ b/eclipsing-binary-simulator/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8" />
-        <title>Eclipsing Binary Simulator</title>
- 
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-        <style type="text/css">
-        body>.container {
+ <head>
+  <meta charset="utf-8"/>
+  <title>
+   Eclipsing Binary Simulator
+  </title>
+  <link crossorigin="anonymous" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" rel="stylesheet"/>
+  <style type="text/css">
+   body>.container {
             width: 1140px;
         }
         #sim-container {
@@ -26,38 +27,45 @@
         input[type="number"][name="noise"],
         input[type="number"][name="planetMass"] {
             width: 84px !important;
-        }        
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <div id="sim-container"></div>
-        </div>
-
-        <div class="modal" id="helpModal" tabindex="-1" role="dialog" aria-labelledby="helpModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="helpModalLabel">Help</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            This simulator models the motions of two
+        }
+  </style>
+ </head>
+ <body>
+  <div class="container">
+   <div id="sim-container">
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="helpModalLabel" class="modal" id="helpModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="helpModalLabel">
+       Help
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p>
+       This simulator models the motions of two
                             stars in orbit around each other. When
                             such a system is aligned properly the
                             stars will eclipse one another, causing a
                             change in brightness (as seen from earth)
                             that allows astronomers to determine the
                             properties of the stars.
-                        </p>
-                        <p>
-                            The upper left panel shows the binary
-                            system visualization. If the <strong>lock
-                            on perspective from earth</strong>
-                            checkbox is selected (found in the lower
+      </p>
+      <p>
+       The upper left panel shows the binary
+                            system visualization. If the
+       <strong>
+        lock
+                            on perspective from earth
+       </strong>
+       checkbox is selected (found in the lower
                             left corner) the system is shown as it
                             would be seen from earth with a
                             sufficiently powerful telescope. If the
@@ -65,18 +73,18 @@
                             visualization around, and a red arrow is
                             shown indicating the direction to the
                             earth.
-                        </p>
-                        <p>
-                            In practice eclipsing binary stars are so
+      </p>
+      <p>
+       In practice eclipsing binary stars are so
                             close together that astronomers see just a
                             single combined 'star'. The plot in the
                             upper right shows the combined brightness
                             of the system. Dips in the lightcurve
                             correspond to the eclipses as seen from
                             earth.
-                        </p>
-                        <p>
-                            The panel in the lower right controls the
+      </p>
+      <p>
+       The panel in the lower right controls the
                             properties of the stars. Note that as you
                             adjust one slider the range of the other
                             sliders may change (indicated by the dark
@@ -85,45 +93,55 @@
                             inclination properties in the left panel
                             control the orientation of the system with
                             respect to earth.
-                        </p>
-                        <p>
-                            You can also load presets from the presets
+      </p>
+      <p>
+       You can also load presets from the presets
                             drop-down box. With some presets observed
                             data will be shown in the lightcurve
                             panel. This data comes from the CALEB
                             catelog, and when selected a button to
                             load the associated CALEB webpage will be
                             enabled.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="modal" id="aboutModal" tabindex="-1" role="dialog" aria-labelledby="aboutModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="aboutModalLabel">About</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            See <a
-                            href="https://github.com/ccnmtl/astro-simulations">github.com/ccnmtl/astro-simulations</a>
-                            for more info.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>        
-
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
-        <script src="dist/bundle.js"></script>
-    </body>
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="aboutModalLabel" class="modal" id="aboutModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="aboutModalLabel">
+       About
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p class="sim-version">
+       eclipsing-binary-simulator 0.1.0 (build date: 2019-02-26)
+      </p>
+      <p>
+       See
+       <a href="https://github.com/ccnmtl/astro-simulations">
+        github.com/ccnmtl/astro-simulations
+       </a>
+       for more info.
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <script crossorigin="anonymous" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" src="https://code.jquery.com/jquery-3.3.1.slim.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js">
+  </script>
+  <script src="dist/bundle.js">
+  </script>
+ </body>
 </html>

--- a/eclipsing-binary-simulator/package.json
+++ b/eclipsing-binary-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eclipsing-binary-simulator",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Eclipsing Binary Simulator",
   "private": true,
   "main": "main.js",

--- a/exoplanet-transit-simulator/index.html
+++ b/exoplanet-transit-simulator/index.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8" />
-        <title>Exoplanet Transit Simulator</title>
- 
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">         <style type="text/css">
-        body>.container {
+ <head>
+  <meta charset="utf-8"/>
+  <title>
+   Exoplanet Transit Simulator
+  </title>
+  <link crossorigin="anonymous" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" rel="stylesheet"/>
+  <style type="text/css">
+   body>.container {
             width: 1140px;
         }
         #sim-container {
@@ -25,33 +27,37 @@
         input[type="number"][name="noise"],
         input[type="number"][name="planetMass"] {
             width: 84px !important;
-        }        
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <div id="sim-container"></div>
-        </div>
-
-        <div class="modal" id="helpModal" tabindex="-1" role="dialog" aria-labelledby="helpModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="helpModalLabel">Help</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            This simulator shows what happens when an
+        }
+  </style>
+ </head>
+ <body>
+  <div class="container">
+   <div id="sim-container">
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="helpModalLabel" class="modal" id="helpModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="helpModalLabel">
+       Help
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p>
+       This simulator shows what happens when an
                             extrasolar planet passes in front of its
                             star. Such eclipses (called transits)
                             allow scientists to detect planets they
                             would not see otherwise.
-                        </p>
-                        <p>
-                            The upper left panel shows the star and
+      </p>
+      <p>
+       The upper left panel shows the star and
                             planet as they would be seen from earth if
                             we had an extremely powerful telescope. In
                             fact, this privileged view is impossible
@@ -60,55 +66,65 @@
                             lightcurve as the planet moves in front of
                             the star. (A lightcurve is a plot of
                             brightness over time.)
-                        </p>
-                        <p>
-                            The lightcurve is shown in the upper right
+      </p>
+      <p>
+       The lightcurve is shown in the upper right
                             panel. The apparent brightness of the star
                             is 'normalized', that is, the brightness
                             is reported as a fraction of the full
                             brightness (when the star is not
                             eclipsed). You have the option of showing
                             simulated noisy measurements and hiding
-                            the theoretical curve &mdash; this gives a
+                            the theoretical curve — this gives a
                             better idea of what it is like working
                             with real data.
-                        </p>
-                        <p>
-                            The planet, star, and system properties
+      </p>
+      <p>
+       The planet, star, and system properties
                             can be set in the lower panels. These
                             parameters can also be set by selecting
                             one of the presets from the dropdown menu
                             in the Presets panel.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="modal" id="aboutModal" tabindex="-1" role="dialog" aria-labelledby="aboutModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="aboutModalLabel">About</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            See <a
-                            href="https://github.com/ccnmtl/astro-simulations">github.com/ccnmtl/astro-simulations</a>
-                            for more info.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>        
-
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
-        <script src="dist/bundle.js"></script>
-    </body>
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="aboutModalLabel" class="modal" id="aboutModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="aboutModalLabel">
+       About
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p class="sim-version">
+       exoplanet-transit-simulator 0.8.0 (build date: 2019-02-26)
+      </p>
+      <p>
+       See
+       <a href="https://github.com/ccnmtl/astro-simulations">
+        github.com/ccnmtl/astro-simulations
+       </a>
+       for more info.
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <script crossorigin="anonymous" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" src="https://code.jquery.com/jquery-3.3.1.slim.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js">
+  </script>
+  <script src="dist/bundle.js">
+  </script>
+ </body>
 </html>

--- a/exoplanet-transit-simulator/package.json
+++ b/exoplanet-transit-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exoplanet-transit-simulator",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "description": "Exoplanet Transit Simulator",
   "private": true,
   "main": "main.js",

--- a/gas-retention-simulator/index.html
+++ b/gas-retention-simulator/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8" />
-        <title>Gas Retention Simulator</title>
-
-       <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"> 
-        <style type="text/css">
-        body>.container {
+ <head>
+  <meta charset="utf-8"/>
+  <title>
+   Gas Retention Simulator
+  </title>
+  <link crossorigin="anonymous" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" rel="stylesheet"/>
+  <style type="text/css">
+   body>.container {
             width: 1140px;
         }
         #sim-container {
@@ -26,26 +27,30 @@
         input[type="number"][name="noise"],
         input[type="number"][name="planetMass"] {
             width: 84px !important;
-        }        
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <div id="sim-container"></div>
-        </div>
-
-        <div class="modal" id="helpModal" tabindex="-1" role="dialog" aria-labelledby="helpModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="helpModalLabel">Help</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            This simulator demonstrates how gases of
+        }
+  </style>
+ </head>
+ <body>
+  <div class="container">
+   <div id="sim-container">
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="helpModalLabel" class="modal" id="helpModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="helpModalLabel">
+       Help
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p>
+       This simulator demonstrates how gases of
                             different molecular masses behave when
                             maintained at thermodynamic equilibrium in
                             a chamber. The chamber can be set to allow
@@ -53,73 +58,101 @@
                             escape, providing an analogy for the
                             bleeding of a planet's atmosphere into
                             space.
-                        </p>
-                        <p>
-                            To begin select a gas from the drop-down
-                            menu in the <strong>Gases</strong> panel.
+      </p>
+      <p>
+       To begin select a gas from the drop-down
+                            menu in the
+       <strong>
+        Gases
+       </strong>
+       panel.
                             You can add up to three gases at a
-                            time. Click the <strong>start
-                            simulation</strong> button in the
-                            <strong>Chamber Properties</strong> panel
+                            time. Click the
+       <strong>
+        start
+                            simulation
+       </strong>
+       button in the
+       <strong>
+        Chamber Properties
+       </strong>
+       panel
                             to see the particles in motion. When the
                             simulation is running the sliders and most
                             other options are disabled, so you will
                             need to stop the simulation to make
                             changes.
-                        </p>
-                        <p>
-                            Note that in this simulation the particles
+      </p>
+      <p>
+       Note that in this simulation the particles
                             in the chamber are meant to be interpreted
-                            as tracer particles &mdash; each particle shown
+                            as tracer particles — each particle shown
                             represents a great many more particles.
-                        </p>
-                        <p>
-                            The bar chart at the left side of the
-                            <strong>Gases</strong> panel indicates the
+      </p>
+      <p>
+       The bar chart at the left side of the
+       <strong>
+        Gases
+       </strong>
+       panel indicates the
                             absoluate amount of each gas in the
                             chamber.  The relative amounts are given
                             as percentages in the gases list.  You can
                             drag the bars to adjust their heights, or
-                            you can click the <strong>reset
-                            proportions</strong> button to restore all
+                            you can click the
+       <strong>
+        reset
+                            proportions
+       </strong>
+       button to restore all
                             the gases to their full amounts.
-                        </p>
-                        <p>
-                            One caveat: phase changes are ignored in
+      </p>
+      <p>
+       One caveat: phase changes are ignored in
                             this simulator. That is, we assume that
                             the particles in the chamber stay in a
                             gaseous state regardless of the
                             temperature or pressure in the chamber.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="modal" id="aboutModal" tabindex="-1" role="dialog" aria-labelledby="aboutModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="aboutModalLabel">About</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            See <a
-                            href="https://github.com/ccnmtl/astro-simulations">github.com/ccnmtl/astro-simulations</a>
-                            for more info.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>        
-
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
-        <script src="dist/bundle.js"></script>
-    </body>
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="aboutModalLabel" class="modal" id="aboutModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="aboutModalLabel">
+       About
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p class="sim-version">
+       gas-retention-simulator 0.0.1 (build date: 2019-02-26)
+      </p>
+      <p>
+       See
+       <a href="https://github.com/ccnmtl/astro-simulations">
+        github.com/ccnmtl/astro-simulations
+       </a>
+       for more info.
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <script crossorigin="anonymous" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" src="https://code.jquery.com/jquery-3.3.1.slim.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js">
+  </script>
+  <script src="dist/bundle.js">
+  </script>
+ </body>
 </html>

--- a/gas-retention-simulator/package.json
+++ b/gas-retention-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-retention-simulator",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Gas Retention Simulator",
   "private": true,
   "main": "main.js",

--- a/lunar-phase-simulator/index.html
+++ b/lunar-phase-simulator/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8" />
-        <title>Lunar Phase Simulator</title>
- 
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">        
-        <style type="text/css">
-        body>.container {
+ <head>
+  <meta charset="utf-8"/>
+  <title>
+   Lunar Phase Simulator
+  </title>
+  <link crossorigin="anonymous" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" rel="stylesheet"/>
+  <style type="text/css">
+   body>.container {
             width: 960px;
         }
         #sim-container {
@@ -27,105 +28,151 @@
             font-weight: bold;
             width: 27px;
         }
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <div id="sim-container"></div>
-        </div>
-
-        <div class="modal" id="helpModal" tabindex="-1" role="dialog" aria-labelledby="helpModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="helpModalLabel">Help</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            This simulator demonstrates the
+  </style>
+ </head>
+ <body>
+  <div class="container">
+   <div id="sim-container">
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="helpModalLabel" class="modal" id="helpModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="helpModalLabel">
+       Help
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p>
+       This simulator demonstrates the
                             correspondence between the moon's position
                             in its orbit, its phase, and its position
                             in an observer's sky at different times of
                             day.
-                        </p>
-                        <p>
-                            The upper left panel shows the orbit
+      </p>
+      <p>
+       The upper left panel shows the orbit
                             visualization. The moon can be dragged
                             around to change its position, and the
                             earth can be dragged around to change its
                             rotation. You can also use the
-                            <strong>Animation and Time
-                            Controls</strong> panel to control the
+       <strong>
+        Animation and Time
+                            Controls
+       </strong>
+       panel to control the
                             simulation.
-                        </p>
-                        <p>
-                            The <strong>Moon Phase</strong> panel
+      </p>
+      <p>
+       The
+       <strong>
+        Moon Phase
+       </strong>
+       panel
                             shows how the moon would appear from earth
                             given the geometry shown in the
-                            visualization panel. The <strong>Horizon
-                            Diagram</strong> panel shows how the sky
+                            visualization panel. The
+       <strong>
+        Horizon
+                            Diagram
+       </strong>
+       panel shows how the sky
                             would appear for the stickfigure shown
                             standing on the globe. Note that this
                             horizon diagram assumes an observer in the
                             mid-northern latitudes (e.g. the
                             continental US).
-                        </p>
-                        <p>
-                            Checking the <strong>show angle</strong>
-                            checkbox in the <strong>Diagram
-                            Options</strong> panel will show the
+      </p>
+      <p>
+       Checking the
+       <strong>
+        show angle
+       </strong>
+       checkbox in the
+       <strong>
+        Diagram
+                            Options
+       </strong>
+       panel will show the
                             elongation angle of the moon in the
                             visualization panel as well as the horizon
                             diagram. The lunar landmark option lets
                             you see a reference point on the moon's
                             near side, which also shows up in the
-                            <strong>Moon Phase</strong> panel. The
+       <strong>
+        Moon Phase
+       </strong>
+       panel. The
                             time tickmarks show the tim of day for
                             various positions around the globe.
-                        </p>
-                        <p>
-                            You may notice that the <strong>Moon
-                            Phase</strong> and <strong>Horizon
-                            Diagram</strong> panels have a
-                            <strong>show/hide</strong> button. This
+      </p>
+      <p>
+       You may notice that the
+       <strong>
+        Moon
+                            Phase
+       </strong>
+       and
+       <strong>
+        Horizon
+                            Diagram
+       </strong>
+       panels have a
+       <strong>
+        show/hide
+       </strong>
+       button. This
                             feature can be useful when using the
                             simulator as a demonstration tool in the
                             classroom. For answering questions in the
                             student guide you will want to keep the
                             panel contents shown.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="modal" id="aboutModal" tabindex="-1" role="dialog" aria-labelledby="aboutModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="aboutModalLabel">About</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            See <a
-                            href="https://github.com/ccnmtl/astro-interactives">github.com/ccnmtl/astro-interactives</a>
-                            for more info.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
-        <script src="dist/bundle.js"></script>
-    </body>
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="aboutModalLabel" class="modal" id="aboutModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="aboutModalLabel">
+       About
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p class="sim-version">
+       lunar-phase-simulator 1.0.0 (build date: 2019-02-26)
+      </p>
+      <p>
+       See
+       <a href="https://github.com/ccnmtl/astro-interactives">
+        github.com/ccnmtl/astro-interactives
+       </a>
+       for more info.
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <script crossorigin="anonymous" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" src="https://code.jquery.com/jquery-3.3.1.slim.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js">
+  </script>
+  <script src="dist/bundle.js">
+  </script>
+ </body>
 </html>

--- a/scripts/update-build-info.py
+++ b/scripts/update-build-info.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Update a sim's version and build info in its index.html
+# based on info from its package.json file.
+#
+
+import json
+import sys
+from datetime import date
+from os.path import join
+from bs4 import BeautifulSoup
+
+
+def format_build_info(name, version, date):
+    return '{} {} (build date: {})'.format(
+        name, version, date)
+
+
+def get_package_data(directory):
+    with open(join(directory, 'package.json')) as f:
+        package_json = f.read()
+
+    return json.loads(package_json)
+
+
+def update_package_info(directory, name, version):
+    with open(join(directory, 'index.html')) as f:
+        index_html = f.read()
+
+    soup = BeautifulSoup(index_html, 'html.parser')
+    el = soup.find('p', class_='sim-version')
+
+    if el:
+        build_info = format_build_info(name, version, date.today())
+        print(build_info)
+
+        el.string = build_info
+
+        with open(join(directory, 'index.html'), 'w') as f:
+            f.write(soup.prettify())
+
+        print('Wrote to {}'.format(join(directory, 'index.html')))
+
+
+def main():
+    if len(sys.argv) < 2:
+        directory = '.'
+        print('update-build-info: Using current directory')
+    else:
+        directory = sys.argv[1]
+        print('update-build-info {}'.format(directory))
+
+    package_data = get_package_data(directory)
+
+    name = package_data.get('name')
+    version = package_data.get('version')
+
+    update_package_info(directory, name, version)
+
+
+if __name__ == '__main__':
+    main()

--- a/small-angle-demo/index.html
+++ b/small-angle-demo/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8" />
-        <title>Small-Angle Approximation Demonstrator</title>
- 
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-        <style type="text/css">
-        #sim-container {
+ <head>
+  <meta charset="utf-8"/>
+  <title>
+   Small-Angle Approximation Demonstrator
+  </title>
+  <link crossorigin="anonymous" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" rel="stylesheet"/>
+  <style type="text/css">
+   #sim-container {
             -webkit-touch-callout: none;
             -webkit-user-select: none;
             -khtml-user-select: none;
@@ -23,37 +24,48 @@
         input[type="number"] {
             width: 80px !important;
         }
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <div id="sim-container"></div>
-        </div>
-
-        <div class="modal" id="aboutModal" tabindex="-1" role="dialog" aria-labelledby="aboutModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="aboutModalLabel">About</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            See <a
-                            href="https://github.com/ccnmtl/astro-simulations">github.com/ccnmtl/astro-simulations</a>
-                            for more info.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>        
-
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
-        <script src="dist/bundle.js"></script>
-    </body>
+  </style>
+ </head>
+ <body>
+  <div class="container">
+   <div id="sim-container">
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="aboutModalLabel" class="modal" id="aboutModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="aboutModalLabel">
+       About
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p class="sim-version">
+       small-angle-demo 1.0.0 (build date: 2019-02-26)
+      </p>
+      <p>
+       See
+       <a href="https://github.com/ccnmtl/astro-simulations">
+        github.com/ccnmtl/astro-simulations
+       </a>
+       for more info.
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <script crossorigin="anonymous" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" src="https://code.jquery.com/jquery-3.3.1.slim.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js">
+  </script>
+  <script src="dist/bundle.js">
+  </script>
+ </body>
 </html>

--- a/sun-motion-simulator/index.html
+++ b/sun-motion-simulator/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8" />
-        <title>Motions of the Sun Simulator</title>
- 
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-
-        <style type="text/css">
-        body>.container {
+ <head>
+  <meta charset="utf-8"/>
+  <title>
+   Motions of the Sun Simulator
+  </title>
+  <link crossorigin="anonymous" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" rel="stylesheet"/>
+  <style type="text/css">
+   body>.container {
             width: 1140px;
         }
         #sim-container {
@@ -54,84 +54,104 @@
             padding: 4px;
             border: 1px solid black;
         }
-        </style>
-    </head>
-    <body>
-        <div class="container">
-            <div id="sim-container"></div>
-        </div>
-
-        <div class="modal" id="helpModal" tabindex="-1" role="dialog" aria-labelledby="helpModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="helpModalLabel">Help</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            This simulator models the motions of the
+  </style>
+ </head>
+ <body>
+  <div class="container">
+   <div id="sim-container">
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="helpModalLabel" class="modal" id="helpModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="helpModalLabel">
+       Help
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p>
+       This simulator models the motions of the
                             sun in the sky using a horizon diagram,
                             demonstrating daily and seasonal changes
                             in the sun's position.
-                        </p>
-                        <p>
-                            The upper left panel shows the horizon
+      </p>
+      <p>
+       The upper left panel shows the horizon
                             diagram visualization. This is a
                             representation of the sky as if it were a
                             large sphere centered on an observer (the
                             stickfigure). The location and local time
                             for this observer are set in the
-                            <strong>Time and Location
-                            Controls</strong> panel.
-                        </p>
-                        <p>
-                            The <strong>General Settings</strong>
-                            panel allows one to show or hide various
+       <strong>
+        Time and Location
+                            Controls
+       </strong>
+       panel.
+      </p>
+      <p>
+       The
+       <strong>
+        General Settings
+       </strong>
+       panel allows one to show or hide various
                             features of the horizon diagram, as well
                             as controlling the behavior when dragging
                             the sun disk on the horizon diagram.
-                        </p>
-                        <p>
-                            When animating, this simulator can run
+      </p>
+      <p>
+       When animating, this simulator can run
                             continuously (as if in fast forward) or it
                             can step by day. Stepping by day keeps the
                             time of day fixed as the day of year
                             changes. For example, one can use this
                             mode to see the path the noon time sun
                             traces over the year.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="modal" id="aboutModal" tabindex="-1" role="dialog" aria-labelledby="aboutModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="aboutModalLabel">About</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            See <a
-                            href="https://github.com/ccnmtl/astro-interactives">github.com/ccnmtl/astro-interactives</a>
-                            for more info.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
-        <script src="dist/bundle.js"></script>
-    </body>
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <div aria-hidden="true" aria-labelledby="aboutModalLabel" class="modal" id="aboutModal" role="dialog" tabindex="-1">
+   <div class="modal-dialog" role="document">
+    <div class="modal-content">
+     <div class="modal-header">
+      <h5 class="modal-title" id="aboutModalLabel">
+       About
+      </h5>
+      <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+       <span aria-hidden="true">
+        ×
+       </span>
+      </button>
+     </div>
+     <div class="modal-body">
+      <p class="sim-version">
+       sun-motion-simulator 0.8.0 (build date: 2019-02-26)
+      </p>
+      <p>
+       See
+       <a href="https://github.com/ccnmtl/astro-interactives">
+        github.com/ccnmtl/astro-interactives
+       </a>
+       for more info.
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+  <script crossorigin="anonymous" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" src="https://code.jquery.com/jquery-3.3.1.slim.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js">
+  </script>
+  <script crossorigin="anonymous" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js">
+  </script>
+  <script src="dist/bundle.js">
+  </script>
+ </body>
 </html>

--- a/sun-motion-simulator/package.json
+++ b/sun-motion-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sun-motion-simulator",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "description": "Motions of the Sun Simulator",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
This was a suggestion from Chris. Adds a new script, `update-build-info.py`, that's called with:

    make update-build-info