### PR TITLE
eclipsing binary star sim: adjust lightcurve plot

### DIFF
--- a/eclipsing-binary-simulator/src/d3/Axes.jsx
+++ b/eclipsing-binary-simulator/src/d3/Axes.jsx
@@ -23,7 +23,9 @@ export default class Axes extends Component {
             0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
         ]);
         const xAxis = d3.axisBottom(this.props.xScale || 1).ticks(10);
-        const yAxis = d3.axisLeft(this.props.yScale).ticks(4);
+        const yAxis = d3.axisLeft(this.props.yScale).tickValues([
+            0, 0.25, 0.5, 0.75, 1
+        ]).tickFormat(d3.format('.2r'));
 
         const node1 = this.xAxis.current;
         d3.select(node1).call(xAxis);

--- a/eclipsing-binary-simulator/src/d3/Plot.jsx
+++ b/eclipsing-binary-simulator/src/d3/Plot.jsx
@@ -144,7 +144,12 @@ export default class Plot extends React.Component {
 
         return (
             <svg width={props.width} height={props.height + props.padding}>
+
                 {imageL} {imageR}
+                <rect fill="white"
+                      width={props.paddingLeft}
+                      height={props.height + props.padding} x="0" y="0" />
+
                 <rect className="plot-pan" pointerEvents="all" fill="none"
                     width={props.width} height={props.height}></rect>
 
@@ -153,8 +158,7 @@ export default class Plot extends React.Component {
                     data={props.lightcurveData}
                     graphWidth={props.width - props.paddingLeft}
                     graphHeight={props.height - props.padding}
-                    {...props} {...scales}
-                />
+                    {...props} {...scales} />
                 <Axes offset={this.state.offset}
                       {...props} {...scales} />
                 <PhaseControl


### PR DESCRIPTION
* Hide overflowing part of preset images
* Adjust y axis labels to match original

![2019-06-13-124317_473x295_scrot](https://user-images.githubusercontent.com/59292/59451190-deaf6600-8dd8-11e9-862b-d4adcda97bbd.png)
