### PR TITLE
Always use UTC time to avoid daylight savings bug - HEL-154

### DIFF
--- a/sun-motion-simulator/src/CelestialSphere.jsx
+++ b/sun-motion-simulator/src/CelestialSphere.jsx
@@ -19,7 +19,7 @@ const hourAngleToRadians = function(hourAngle) {
     const radians = -(hourAngle / 24) * (Math.PI * 2)
                   - Math.PI;
     return radians;
-}
+};
 
 // three.js/react integration based on:
 // https://stackoverflow.com/a/46412546/173630
@@ -176,7 +176,7 @@ export default class CelestialSphere extends React.Component {
         this.orbitGroup.add(this.sunDeclination);
         this.orbitGroup.add(this.celestialEquator);
 
-        this.analemma = this.drawAnalemma(scene)
+        this.analemma = this.drawAnalemma(scene);
         this.analemma.position.z += 2;
         this.orbitGroup.add(this.analemma);
 
@@ -429,7 +429,7 @@ export default class CelestialSphere extends React.Component {
         plane.position.y = 0.1;
         plane.rotation.x = Math.PI / 2;
 
-        const domeGroup = new THREE.Group()
+        const domeGroup = new THREE.Group();
         domeGroup.add(solidBlackDome);
         domeGroup.add(plane);
 
@@ -673,7 +673,7 @@ export default class CelestialSphere extends React.Component {
         const AnalemmaCurve = function(scale) {
             THREE.Curve.call(this);
             this.scale = (scale === undefined) ? 1 : scale;
-        }
+        };
 
         AnalemmaCurve.prototype = Object.create(THREE.Curve.prototype);
         AnalemmaCurve.prototype.constructor = AnalemmaCurve;
@@ -770,7 +770,7 @@ export default class CelestialSphere extends React.Component {
     }
 
     stop() {
-        cancelAnimationFrame(this.frameId)
+        cancelAnimationFrame(this.frameId);
     }
 
     animate() {
@@ -868,7 +868,7 @@ export default class CelestialSphere extends React.Component {
 
         return (
             <div id={this.id}
-                 ref={(mount) => { this.mount = mount }}>
+                 ref={(mount) => { this.mount = mount; }}>
                 <canvas
                     onMouseMove={this.onMouseMove}
                     id={this.id + 'Canvas'} width={860} height={860} />
@@ -985,8 +985,8 @@ export default class CelestialSphere extends React.Component {
             const angle = Math.atan2(closestPoint.y, closestPoint.x);
             const time = this.getTime(angle);
             const d = new Date(this.props.dateTime);
-            d.setHours(time.getHours());
-            d.setMinutes(time.getMinutes());
+            d.setUTCHours(time.getHours());
+            d.setUTCMinutes(time.getMinutes());
             return this.props.onDateTimeUpdate(d);
         }
 

--- a/sun-motion-simulator/src/Clock.jsx
+++ b/sun-motion-simulator/src/Clock.jsx
@@ -68,12 +68,12 @@ export default class Clock extends React.Component {
     componentDidUpdate(prevProps) {
         if (prevProps.dateTime !== this.props.dateTime) {
             // Update the clock.
-            const minutes = this.props.dateTime.getMinutes();
-            const seconds = this.props.dateTime.getSeconds();
+            const minutes = this.props.dateTime.getUTCMinutes();
+            const seconds = this.props.dateTime.getUTCSeconds();
             this.minuteHand.rotation = (minutes / 60) * (Math.PI * 2) - Math.PI
                                      + ((seconds / 60 / 60) * (Math.PI * 2));
 
-            const hours = this.props.dateTime.getHours();
+            const hours = this.props.dateTime.getUTCHours();
             this.hourHand.rotation = ((hours + (minutes / 60)) / 24) * (
                 Math.PI * 2) - Math.PI;
         }
@@ -217,8 +217,8 @@ export default class Clock extends React.Component {
         const hours = forceNumber(time[0]);
         const minutes = forceNumber(time[1]);
         const d = new Date(this.props.dateTime);
-        d.setHours(hours);
-        d.setMinutes(minutes);
+        d.setUTCHours(hours);
+        d.setUTCMinutes(minutes);
         return this.props.onDateTimeUpdate(d);
     }
     onMinuteDragStart(e) {

--- a/sun-motion-simulator/src/DatePicker.jsx
+++ b/sun-motion-simulator/src/DatePicker.jsx
@@ -8,7 +8,7 @@ export default class DatePicker extends React.Component {
         super(props);
         this.state = {
             isDragging: false,
-            dayField: props.dateTime.getDate()
+            dayField: props.dateTime.getUTCDate()
         };
 
         this.onDragStart = this.onDragStart.bind(this);
@@ -33,7 +33,7 @@ export default class DatePicker extends React.Component {
                 </label>
                 <select className="form-control form-control-sm ml-2"
                         onChange={this.props.onMonthUpdate}
-                        value={this.props.dateTime.getMonth()}>
+                        value={this.props.dateTime.getUTCMonth()}>
                     <option value={0}>January</option>
                     <option value={1}>February</option>
                     <option value={2}>March</option>
@@ -71,7 +71,7 @@ export default class DatePicker extends React.Component {
     }
     componentDidUpdate(prevProps) {
         if (prevProps.dateTime !== this.props.dateTime) {
-            const day = this.props.dateTime.getDate();
+            const day = this.props.dateTime.getUTCDate();
             if (day !== this.state.dayField) {
                 this.setState({dayField: day});
             }
@@ -184,7 +184,7 @@ export default class DatePicker extends React.Component {
      * This control only modifies the day, not the time.
      */
     localPosToDate(x, app) {
-        const year = this.props.dateTime.getFullYear();
+        const year = this.props.dateTime.getUTCFullYear();
         const d = new Date(`1/1/${year}`);
         const dayOfYear = (x / (app.view.width - 20)) * 365.25;
 

--- a/sun-motion-simulator/src/main.jsx
+++ b/sun-motion-simulator/src/main.jsx
@@ -21,11 +21,11 @@ class SunMotionSim extends React.Component {
     constructor(props) {
         super(props);
         this.initialState = {
-            dateTime: new Date(
+            dateTime: new Date(Date.UTC(
                 // Use current year
                 (new Date()).getFullYear(),
                 // Initial state is always May 27th, at noon
-                4, 27, 12),
+                4, 27, 12)),
 
             // These three properties are calculated off of the
             // dateTime by onDateUpdate.
@@ -315,7 +315,7 @@ class SunMotionSim extends React.Component {
         if (!this.state.stepByDay && this.state.loopDay) {
             // If loopDay is selected, then always keep newDate on
             // the current day while letting the time increment.
-            const dayOfMonth = this.state.dateTime.getDate();
+            const dayOfMonth = this.state.dateTime.getUTCDate();
             newDate.setDate(dayOfMonth);
         }
 
@@ -399,9 +399,9 @@ class SunMotionSim extends React.Component {
      * All the control-specific logic is handled in DatePicker.jsx.
      */
     onDateControlUpdate(newDate) {
-        newDate.setHours(this.state.dateTime.getHours());
-        newDate.setMinutes(this.state.dateTime.getMinutes());
-        newDate.setSeconds(this.state.dateTime.getSeconds());
+        newDate.setUTCHours(this.state.dateTime.getUTCHours());
+        newDate.setUTCMinutes(this.state.dateTime.getUTCMinutes());
+        newDate.setUTCSeconds(this.state.dateTime.getUTCSeconds());
         this.setState({dateTime: newDate});
     }
 }

--- a/sun-motion-simulator/src/utils.js
+++ b/sun-motion-simulator/src/utils.js
@@ -136,7 +136,7 @@ const getHourAngle = function(siderealTime, rightAscension) {
  * Taken from: https://stackoverflow.com/a/8619946
  */
 const getDayOfYear = function(d) {
-    const start = new Date(d.getFullYear(), 0, 0);
+    const start = new Date(Date.UTC(d.getFullYear(), 0, 0));
     const diff = (d - start) + (
         (start.getTimezoneOffset() - d.getTimezoneOffset()) * 60 * 1000);
     const oneDay = 1000 * 60 * 60 * 24;
@@ -144,9 +144,9 @@ const getDayOfYear = function(d) {
 
     // Add the time of day as a fraction of 1.
     let time = 0;
-    time += d.getHours() / 24;
-    time += d.getMinutes() / 60 / 24;
-    time += d.getSeconds() / 60 / 60 / 24;
+    time += d.getUTCHours() / 24;
+    time += d.getUTCMinutes() / 60 / 24;
+    time += d.getUTCSeconds() / 60 / 60 / 24;
 
     day += time;
     return day;


### PR DESCRIPTION
You can see this bug happen by setting Animation Mode to "Step by Day",
and watching the sun jump in position, and the clock move an hour, when
daylight savings changes happen (early March and early November).

I've updated the code to get and set times in UTC mode instead of the
client's local time zone, which we don't care about for these simulation
purposes.

Though, I will note the position of the sun is based on Lincoln,
Nebraska, where these simulations originated.