### PR TITLE
Use Math.floor() instead of Math.round() in minutes display

### DIFF
--- a/sun-motion-simulator/src/utils.js
+++ b/sun-motion-simulator/src/utils.js
@@ -177,7 +177,7 @@ const formatHours = function(n) {
     n = Math.abs(n);
     const hours = Math.floor(n);
     const r = n - hours;
-    const minutes = forceNumber(Math.round(r * 60));
+    const minutes = forceNumber(Math.floor(r * 60));
 
     const negDisplay = isNegative ? '-' : '';
     return `${negDisplay}${hours}h ${minutes}m`;

--- a/sun-motion-simulator/src/utils.test.js
+++ b/sun-motion-simulator/src/utils.test.js
@@ -67,6 +67,10 @@ test('formats hours/minutes correctly', () => {
     expect(formatHours(1)).toBe('1h 0m');
     expect(formatHours(2.25)).toBe('2h 15m');
     expect(formatHours(-2.25)).toBe('-2h 15m');
+    expect(formatHours(0.999999)).toBe('0h 59m');
+    expect(formatHours(2.999999)).toBe('2h 59m');
+    expect(formatHours(-0.9999)).toBe('-0h 59m');
+    expect(formatHours(-5.99)).toBe('-5h 59m');
 });
 
 test('rounds numbers to one place', () => {


### PR DESCRIPTION
Minutes should never be displayed as '60m' here. I think it makes sense
to just floor() this value. This is a display value, and it can be assumed that
"0h 59m" means 0 hours, 59 minutes, and however many milliseconds, which
aren't displayed.

So, an hour angle of 0.9999999999 will display "0h 59m".

closes #1738