### PR TITLE
Fix azimuth calculation bug - HEL-79

### DIFF
--- a/sun-motion-simulator/src/main.jsx
+++ b/sun-motion-simulator/src/main.jsx
@@ -258,7 +258,7 @@ class SunMotionSim extends React.Component {
             this.setState(this.onDateUpdate(this.state.dateTime));
         }
 
-        if (prevState.dateTime !== this.state.dateTime ||
+        if (prevState.hourAngle !== this.state.hourAngle ||
             prevState.latitude !== this.state.latitude
         ) {
             const zenith = getSolarZenith(


### PR DESCRIPTION
Update azimuth when hourAngle is updated, not dateTime. hourAngle is
derived from dateTime, and my componentDidUpdate handler for the azimuth
was getting slightly out of sync here.