### PR TITLE
Fix bug where time input was blank at 12am

### DIFF
--- a/sun-motion-simulator/src/Clock.jsx
+++ b/sun-motion-simulator/src/Clock.jsx
@@ -192,7 +192,7 @@ export default class Clock extends React.Component {
         return d.toLocaleTimeString([], {
             hour: '2-digit',
             minute: '2-digit',
-            hour12: false,
+            hourCycle: 'h23',
             timeZone: 'UTC'
         });
     }

--- a/sun-motion-simulator/src/main.jsx
+++ b/sun-motion-simulator/src/main.jsx
@@ -101,7 +101,7 @@ class SunMotionSim extends React.Component {
                                   .toLocaleTimeString([], {
                                       hour: '2-digit',
                                       minute: '2-digit',
-                                      hour12: false,
+                                      hourCycle: 'h23',
                                       timeZone: 'UTC'
                                   });
 


### PR DESCRIPTION
Midnight was being formatted as 24:00 instead of 00:00, breaking the
time <input>.

Using the hourCycle option instead of hour12 fixes that:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat