### PR TITLE
EBS: remove number input width override - HEL-184

### DIFF
--- a/eclipsing-binary-simulator/index.html
+++ b/eclipsing-binary-simulator/index.html
@@ -28,15 +28,6 @@
       cursor: move;
   }
 
-  input[type="number"] {
-      width: 70px !important;
-  }
-  input[type="number"][name="inclination"],
-  input[type="number"][name="noise"],
-  input[type="number"][name="planetMass"] {
-      width: 84px !important;
-  }
-
   .window {
       z-index: 2;
       border: 1px solid black;


### PR DESCRIPTION
This CSS setting was causing the number inputs to be too narrow.