### PR TITLE
Add a max-width to number inputs

### DIFF
--- a/eclipsing-binary-simulator/index.html
+++ b/eclipsing-binary-simulator/index.html
@@ -9,6 +9,9 @@
   <style type="text/css">
    body>.container {
       width: 1140px;
+   }
+  input[type="number"] {
+      max-width: 91px;
   }
   #sim-container {
       -webkit-touch-callout: none;


### PR DESCRIPTION
The input width was growing really wide when the min or max was set to a
number with many decimal places.