### PR TITLE
Eclipsing Binary sim: Fix problem with black curve

### DIFF
--- a/eclipsing-binary-simulator/src/d3/Plot.jsx
+++ b/eclipsing-binary-simulator/src/d3/Plot.jsx
@@ -40,9 +40,7 @@ class Line extends React.Component {
             line = d3
                 .line()
                 .x(function(d) {
-                    const xPos = x(
-                        (d[0] + me.props.offset) / me.props.width
-                    );
+                    const xPos = x(d[0] / me.props.width);
                     return xPos;
                 })
                 .y(function(d) {


### PR DESCRIPTION
The straight curve no longer disappears after changing the inclination
and scrolling left or right.