### PR TITLE
fix AnalemmaCurve instanciation

### DIFF
--- a/sun-motion-simulator/src/CelestialSphere.jsx
+++ b/sun-motion-simulator/src/CelestialSphere.jsx
@@ -698,27 +698,26 @@ export default class CelestialSphere extends React.Component {
         const n = 200;
         const a = this.initAnalemmaArray(n);
 
-        const AnalemmaCurve = function(scale) {
-            THREE.Curve.call(this);
-            this.scale = (scale === undefined) ? 1 : scale;
-        };
+        class AnalemmaCurve extends THREE.Curve {
+            constructor(scale){
+                super()
+                this.scale = scale ?? 1;
+            }
 
-        AnalemmaCurve.prototype = Object.create(THREE.Curve.prototype);
-        AnalemmaCurve.prototype.constructor = AnalemmaCurve;
-
-        AnalemmaCurve.prototype.getPoint = function(t) {
-            const idx = Math.round(t * (n - 1));
-            const v = a[parseInt(idx)];
-
-            // The curve is invisible unless you use 't' somewhere in
-            // the vector co-ordinates. I don't know why this is
-            // happening. I'm sure there's a better way to work around
-            // this, but for now, just add a really small value based on
-            // t to x.
-            const w = t / 99999999;
-            return new THREE.Vector3(v.x + w, 1.15 * v.z, 1.2 * v.y)
-                            .multiplyScalar(this.scale);
-        };
+            getPoint = t => {
+                const idx = Math.round(t * (n - 1));
+                const v = a[parseInt(idx)];
+    
+                // The curve is invisible unless you use 't' somewhere in
+                // the vector co-ordinates. I don't know why this is
+                // happening. I'm sure there's a better way to work around
+                // this, but for now, just add a really small value based on
+                // t to x.
+                const w = t / 99999999;
+                return new THREE.Vector3(v.x + w, 1.15 * v.z, 1.2 * v.y)
+                                .multiplyScalar(this.scale);
+            };
+        }
 
         const path = new AnalemmaCurve(49);
         const geometry = new THREE.TubeBufferGeometry(

--- a/sun-motion-simulator/src/CelestialSphere.jsx
+++ b/sun-motion-simulator/src/CelestialSphere.jsx
@@ -700,11 +700,11 @@ export default class CelestialSphere extends React.Component {
 
         class AnalemmaCurve extends THREE.Curve {
             constructor(scale){
-                super()
+                super();
                 this.scale = scale ?? 1;
             }
 
-            getPoint = t => {
+            getPoint(t) {
                 const idx = Math.round(t * (n - 1));
                 const v = a[parseInt(idx)];
     


### PR DESCRIPTION
Hi,
This fixes a bug in `sun-motion-simulator` :
```javascript
Uncaught TypeError: Class constructor Curve cannot be invoked without 'new'
    at new AnalemmaCurve (CelestialSphere.jsx:619)
    at CelestialSphere.drawAnalemma (CelestialSphere.jsx:638)
    at CelestialSphere.componentDidMount (CelestialSphere.jsx:204)
    at commitLifeCycles (react-dom.development.js:20658)
    at commitLayoutEffects (react-dom.development.js:23421)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994)
    at invokeGuardedCallback (react-dom.development.js:4056)
    at commitRootImpl (react-dom.development.js:23146)
    at unstable_runWithPriority (scheduler.development.js:468)
```