### PR TITLE
Tweak Eclipsing Binary simulation y-scale to better see shallow (< 10% depth) eclipses

### DIFF
--- a/eclipsing-binary-simulator/src/d3/Axes.jsx
+++ b/eclipsing-binary-simulator/src/d3/Axes.jsx
@@ -23,9 +23,8 @@ export default class Axes extends Component {
             0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
         ]);
         const xAxis = d3.axisBottom(this.props.xScale || 1).ticks(10);
-        const yAxis = d3.axisLeft(this.props.yScale).tickValues([
-            0, 0.25, 0.5, 0.75, 1
-        ]).tickFormat(d3.format('.2r'));
+        const yAxis = d3.axisLeft(this.props.yScale).ticks(4)
+                        .tickFormat(d3.format('.3r'));
 
         const node1 = this.xAxis.current;
         d3.select(node1).call(xAxis);

--- a/eclipsing-binary-simulator/src/d3/Plot.jsx
+++ b/eclipsing-binary-simulator/src/d3/Plot.jsx
@@ -17,10 +17,22 @@ const xScale = props => {
 // Returns a function that "scales" Y coordinates from the data to fit
 // the chart.
 const yScale = props => {
-    const domain = d3.extent(props.lightcurveData, d => d[1]);
+    // Convert flux in lightcurveData to normalized flux (what's visually presented)
+    // so as to scale the y-axis accordingly
+    const flux = props.lightcurveData.map(d => d[1]);
+    flux.sort();
+    const halfIdx = Math.floor(flux.length / 2);
+    const fluxMedian = flux[halfIdx];
+    const fluxNorm = flux.map(d => d / fluxMedian);
+
+    const yExtent = d3.extent(fluxNorm);
+    const diff = yExtent[1] - yExtent[0];
+    // Add 10% space above and below the lightcurve.
+    const dataPad = diff / 10;
+
     return d3
         .scaleLinear()
-        .domain([0, 1.1])
+        .domain([yExtent[0] - dataPad, yExtent[1] + dataPad])
         .range([props.height - props.padding, props.padding]);
 };
 


### PR DESCRIPTION
In current EB simulation, eclipses, e.g., those with depth < 10%, is hard to see in the lightcurve plot, given the y-axis is fixed from 0 to 1.

The PR changes the y-axis scale to fit the eclipses tightly, borrowing the logic from planet transit simulation.

As an (extreme) example, for eclipses produced between a A-type star and a hot subdwarf pair, the current simulation shows:

![image](https://github.com/user-attachments/assets/3550e39e-aebf-418d-ba55-d76e2b054bcb)

This PR changes it to:
![image](https://github.com/user-attachments/assets/d02d027a-532c-4335-897c-6f073e37dabb)



